### PR TITLE
Fix mobile layout issues

### DIFF
--- a/index.html
+++ b/index.html
@@ -383,6 +383,19 @@
           opacity: 1;
         }
       }
+</style>
+<style>
+      @media screen and (max-width: 640px) {
+        #rec603004659 .t396__artboard { text-align: center; margin-top: 20px !important; }
+        #rec603004659 [data-elem-id="1685728400262"],
+        #rec603004659 [data-elem-id="1685728400287"] {
+          position: static !important;
+          display: inline-block;
+          margin: 0 5px;
+          left: auto !important;
+          top: auto !important;
+        }
+      }
     </style>
   </head>
   <body class="t-body" style="margin: 0">
@@ -4907,19 +4920,19 @@
           }
           @media screen and (max-width: 959px) {
             #rec617490154 .tn-elem[data-elem-id="1686334071085"] {
-              top: 122px;
+              top: 170px;
               left: calc(50% - 320px + 217px);
             }
           }
           @media screen and (max-width: 639px) {
             #rec617490154 .tn-elem[data-elem-id="1686334071085"] {
-              top: 122px;
+              top: 170px;
               left: calc(50% - 240px + 137px);
             }
           }
           @media screen and (max-width: 479px) {
             #rec617490154 .tn-elem[data-elem-id="1686334071085"] {
-              top: 123px;
+              top: 171px;
               left: calc(50% - 160px + 57px);
             }
           }
@@ -5069,11 +5082,11 @@
               data-animate-mobile="y"
               data-field-filewidth-value="206"
               data-field-fileheight-value="24"
-              data-field-top-res-320-value="123"
+              data-field-top-res-320-value="171"
               data-field-left-res-320-value="57"
-              data-field-top-res-480-value="122"
+              data-field-top-res-480-value="170"
               data-field-left-res-480-value="137"
-              data-field-top-res-640-value="122"
+              data-field-top-res-640-value="170"
               data-field-left-res-640-value="217"
             >
               <div class="tn-atom">
@@ -7421,7 +7434,7 @@
             }
           }
         </style>
-        <div class="t396" style="margin-bottom: 150px;">
+        <div class="t396" style="margin-bottom: 50px;">
           <div
             class="t396__artboard"
             data-artboard-recid="603004659"


### PR DESCRIPTION
## Summary
- fix top position for the third timeline item on mobile screens
- center images in the dress code section and reduce its bottom spacing

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685e376a6498832c88706c7ef52931c4